### PR TITLE
Better babel integration

### DIFF
--- a/examples/babelrc/.babelrc
+++ b/examples/babelrc/.babelrc
@@ -1,5 +1,6 @@
 {
     "presets": ["stage-1", "react"],
+    "plugins": ["transform-decorators-legacy"],
     "env": {
         "production": {
             "presets": ["stage-1", "react", "react-optimize"]

--- a/examples/babelrc/package.json
+++ b/examples/babelrc/package.json
@@ -2,8 +2,9 @@
   "name": "roc-package-module-test-babelrc",
   "version": "1.0.0",
   "description": "Test of roc-package-module",
-  "main": "lib/es5/index.js",
-  "jsnext:main": "lib/es6/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "jsnext:main": "lib/esm/index.js",
   "scripts": {
     "build": "NODE_ENV=production roc build",
     "dev": "roc dev"
@@ -11,9 +12,10 @@
   "author": "Verdens Gang AS",
   "license": "MIT",
   "devDependencies": {
-    "babel-preset-react": "~6.11.1",
+    "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-preset-react": "~6.16.0",
     "babel-preset-react-optimize": "1.0.1",
-    "babel-preset-stage-1": "~6.5.0",
+    "babel-preset-stage-1": "~6.16.0",
     "roc-package-module-dev": "*"
   }
 }

--- a/examples/babelrc/roc.config.js
+++ b/examples/babelrc/roc.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    babel: {
+        presets: ['stage-1', 'react'],
+        plugins: ['transform-decorators-legacy'],
+        env: {
+            production: {
+                presets: ['react-optimize'],
+            },
+            hest: {
+                presets: []
+            }
+        }
+    }
+}

--- a/examples/babelrc/src/Component.js
+++ b/examples/babelrc/src/Component.js
@@ -8,8 +8,11 @@ const Decorate = (target) => {
 
 @Decorate
 export default class Hello extends Component {
+    static propTypes = {
+        name: React.PropTypes.string
+    };
 
     render() {
-        return <div className={styles.hest}>Hello World</div>;
+        return <div className={styles.hest}>Hello { this.props.name }</div>;
     }
 }

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -2,8 +2,9 @@
   "name": "roc-package-module-test-simple",
   "version": "1.0.0",
   "description": "Test of roc-package-module",
-  "main": "lib/es5/index.js",
-  "jsnext:main": "lib/es6/index.js",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "jsnext:main": "lib/esm/index.js",
   "scripts": {
     "build": "roc build",
     "dev": "roc dev"

--- a/extensions/roc-package-module-dev/.eslintrc
+++ b/extensions/roc-package-module-dev/.eslintrc
@@ -14,6 +14,10 @@
         "babel/generator-star-spacing": [2, { before: false, after: true }],
 
         "import/order": [2, { "groups": ["builtin", "external", "internal", "parent", "sibling", "index"], "newlines-between": "always"}],
-        "import/newline-after-import": [2]
+        "import/newline-after-import": [2],
+
+        "no-use-before-define": 0,
+        "no-param-reassign": 0,
+        "prefer-template": 0
     }
 }

--- a/extensions/roc-package-module-dev/package.json
+++ b/extensions/roc-package-module-dev/package.json
@@ -28,13 +28,20 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel-cli": "~6.5.1",
-    "babel-preset-es2015": "~6.5.0",
-    "babel-preset-es2015-webpack": "~6.3.14",
+    "babel-core": "~6.17.0",
+    "babel-preset-latest": "~6.16.0",
     "chalk": "~1.1.1",
+    "chokidar": "~1.6.0",
+    "fs-readdir-recursive": "1.0.0",
+    "glob": "~7.1.0",
+    "lodash": "~4.16.2",
+    "output-file-sync": "~1.1.2",
+    "path-exists": "~3.0.0",
     "pretty-ms": "~2.1.0",
-    "roc": "1.0.0-rc.11",
-    "roc-abstract-package-base-dev": "1.0.0-beta.1"
+    "roc": "^1.0.0-rc.11",
+    "roc-abstract-package-base-dev": "^1.0.0-beta.1",
+    "roc-plugin-babel": "^1.0.0-beta.1",
+    "slash": "~1.0.0"
   },
   "devDependencies": {
     "babel-eslint": "~6.1.2",

--- a/extensions/roc-package-module-dev/src/actions/build.js
+++ b/extensions/roc-package-module-dev/src/actions/build.js
@@ -1,46 +1,45 @@
 import prettyMs from 'pretty-ms';
-import { execute, getAbsolutePath, initLog } from 'roc';
+import { getAbsolutePath, initLog } from 'roc';
 import { getValueFromPotentialObject } from 'roc-abstract-package-base-dev';
 
 import meta from '../config/roc.config.meta.js';
 import { invokeHook } from '../roc/util';
 
-import isSomeTargetValid from './some-valid-target';
+import isSomeTargetValid from './helpers/isSomeTargetValid';
+import babel from './helpers/babel';
 
 const log = initLog();
 
 const buildWithBabel = (target, settings) => {
-    if (meta.settings.build.targets.validator([target]) !== true) {
-        return Promise.resolve();
-    }
+    if (meta.settings.build.targets.validator([target]) === true) {
+        const babelConfig = invokeHook('babel-config', target);
 
-    return new Promise(async function build(resolve) {
-        const presets = invokeHook('babel-load-presets', target);
-        const plugins = invokeHook('babel-load-plugins', target);
-
-        const babel = require.resolve('babel-cli/bin/babel');
         const src = getAbsolutePath(getValueFromPotentialObject(settings.build.input, target));
         const out = getAbsolutePath(getValueFromPotentialObject(settings.build.output, target));
 
         /* eslint-disable no-console */
         log.small.info(`Building for ${target.toUpperCase()}`);
         /* eslint-enable */
-        const startTime = process.hrtime();
 
         try {
-            await execute(`${babel} ${src} --out-dir ${out} --presets=${presets.join(',')} ` +
-                `--plugins=${plugins.join(',')} --source-maps --copy-files`);
+            babel({
+                src,
+                out,
+                sourceMaps: true,
+                copyFiles: true,
+            }, babelConfig);
         } catch (err) {
+            // eslint-disable-next-line
+            if (err._babel && err instanceof SyntaxError) {
+                // Display codeFrame if it is an Babel Error
+                err.message = `${err.message}\n${err.codeFrame}`;
+            }
             log.small.error(`The ${target.toUpperCase()} build failed. ` +
                 'All other potential builds will be canceled.', err);
         }
 
-        const totalTime = process.hrtime(startTime);
-
-        log.small.success(`Completed ${target.toUpperCase()} in ` +
-            `${prettyMs((totalTime[0] * 1000) + (totalTime[1] / 1000000))}`);
-        resolve();
-    });
+        log.small.success(`Completed ${target.toUpperCase()}\n`);
+    }
 };
 
 /**
@@ -53,7 +52,16 @@ const buildWithBabel = (target, settings) => {
 export default ({ context: { config: { settings } } }) => (targets) => {
     // If not at least on of the targets matches the valid ones it will ignore it. Makes it smarter when combining.
     if (isSomeTargetValid(targets)) {
-        return () => () => Promise.all(targets.map((target) => buildWithBabel(target, settings)));
+        return () => () => new Promise((resolve) => {
+            const startTime = process.hrtime();
+            targets.forEach((target) => buildWithBabel(target, settings));
+            const totalTime = process.hrtime(startTime);
+
+            log.small.success('All module builds completed in ' +
+                `${prettyMs((totalTime[0] * 1000) + (totalTime[1] / 1000000))}`);
+
+            resolve();
+        });
     }
 
     return undefined;

--- a/extensions/roc-package-module-dev/src/actions/dev.js
+++ b/extensions/roc-package-module-dev/src/actions/dev.js
@@ -1,20 +1,19 @@
-import { execute, getAbsolutePath } from 'roc';
+import { getAbsolutePath } from 'roc';
 import { getValueFromPotentialObject } from 'roc-abstract-package-base-dev';
 
 import meta from '../config/roc.config.meta.js';
 import { invokeHook } from '../roc/util';
 
-import isSomeTargetValid from './some-valid-target';
+import isSomeTargetValid from './helpers/isSomeTargetValid';
+import babel from './helpers/babel';
 
-async function devWithBabel(target, settings) {
+function devWithBabel(target, settings) {
     if (meta.settings.build.targets.validator([target]) !== true) {
         return;
     }
 
-    const presets = invokeHook('babel-load-presets', target);
-    const plugins = invokeHook('babel-load-plugins', target);
+    const babelConfig = invokeHook('babel-config', target);
 
-    const babel = require.resolve('babel-cli/bin/babel');
     const src = getAbsolutePath(getValueFromPotentialObject(settings.build.input, target));
     const out = getAbsolutePath(getValueFromPotentialObject(settings.build.output, target));
 
@@ -22,8 +21,13 @@ async function devWithBabel(target, settings) {
     console.log(`Starting in watch mode for ${target.toUpperCase()}`);
     /* eslint-enable */
 
-    await execute(`${babel} ${src} --out-dir ${out} --presets=${presets.join(',')} ` +
-        `--plugins=${plugins.join(',')} --source-maps --copy-files --watch`);
+    babel({
+        src,
+        out,
+        sourceMaps: true,
+        copyFiles: true,
+        watch: true,
+    }, babelConfig);
 }
 
 /**

--- a/extensions/roc-package-module-dev/src/actions/helpers/babel/index.js
+++ b/extensions/roc-package-module-dev/src/actions/helpers/babel/index.js
@@ -1,0 +1,105 @@
+/**
+ Parts of the code taken from babel-cli
+*/
+
+import fs from 'fs';
+import path from 'path';
+
+import { uniq, each } from 'lodash';
+import glob from 'glob';
+import outputFileSync from 'output-file-sync';
+import pathExists from 'path-exists';
+import readdir from 'fs-readdir-recursive';
+import slash from 'slash';
+
+import * as util from './utils';
+
+export default function babelBuilder(cliOptions, babelOptions) {
+    let filenames = [cliOptions.src]
+    .reduce((globbed, input) => {
+        let files = glob.sync(input);
+        if (!files.length) files = [input];
+
+        return globbed.concat(files);
+    }, []);
+
+    filenames = uniq(filenames);
+
+    filenames.forEach(handle);
+
+    if (cliOptions.watch) {
+        const chokidar = require('chokidar'); // eslint-disable-line
+
+        each(filenames, (dirname) => {
+            const watcher = chokidar.watch(dirname, {
+                persistent: true,
+                ignoreInitial: true,
+            });
+
+            each(['add', 'change'], (type) => {
+                watcher.on(type, (filename) => {
+                    const relative = path.relative(dirname, filename) || filename;
+                    try {
+                        handleFile(filename, relative);
+                    } catch (err) {
+                        console.error(err.stack);
+                    }
+                });
+            });
+        });
+    }
+
+    function write(src, relative) {
+        // remove extension and then append back on .js
+        relative = relative.replace(/\.(\w*?)$/, '') + '.js';
+
+        const dest = path.join(cliOptions.out, relative);
+
+        const data = util.compile(src, {
+            sourceMaps: cliOptions.sourceMaps,
+            sourceFileName: slash(path.relative(dest + '/..', src)),
+            sourceMapTarget: path.basename(relative),
+            ...babelOptions,
+        }, cliOptions.watch);
+        if (!cliOptions.copyFiles && data.ignored) return;
+
+        // we've requested explicit sourcemaps to be written to disk
+        if (data.map && cliOptions.sourceMaps && cliOptions.sourceMaps !== 'inline') {
+            const mapLoc = dest + '.map';
+            data.code = util.addSourceMappingUrl(data.code, mapLoc);
+            outputFileSync(mapLoc, JSON.stringify(data.map));
+        }
+
+        outputFileSync(dest, data.code);
+        util.chmod(src, dest);
+
+        util.log(src + ' -> ' + dest);
+    }
+
+    function handleFile(src, filename) {
+        if (util.canCompile(filename, ['.js', '.jsx', '.es6', '.es'])) {
+            write(src, filename);
+        } else if (cliOptions.copyFiles) {
+            const dest = path.join(cliOptions.out, filename);
+            outputFileSync(dest, fs.readFileSync(src));
+            util.chmod(src, dest);
+        }
+    }
+
+    function handle(filename) {
+        if (!pathExists.sync(filename)) return;
+
+        const stat = fs.statSync(filename);
+
+        if (stat.isDirectory(filename)) {
+            const dirname = filename;
+
+            each(readdir(dirname), (currentFilename) => {
+                const src = path.join(dirname, currentFilename);
+                handleFile(src, currentFilename);
+            });
+        } else {
+            write(filename, filename);
+        }
+    }
+}

--- a/extensions/roc-package-module-dev/src/actions/helpers/babel/utils.js
+++ b/extensions/roc-package-module-dev/src/actions/helpers/babel/utils.js
@@ -1,0 +1,54 @@
+/**
+ Parts of the code taken from babel-cli
+*/
+
+import fs from 'fs';
+import path from 'path';
+
+import { transform as transformCore, util } from 'babel-core';
+
+export function chmod(src, dest) {
+    fs.chmodSync(dest, fs.statSync(src).mode);
+}
+
+export const canCompile = util.canCompile;
+
+export function addSourceMappingUrl(code, loc) {
+    return code + '\n//# sourceMappingURL=' + path.basename(loc);
+}
+
+export function log(msg) {
+    console.log(msg);
+}
+
+export function transform(filename, code, opts) {
+    opts.filename = filename;
+
+    const result = transformCore(code, opts);
+    result.filename = filename;
+    result.actual = code;
+    return result;
+}
+
+export function compile(filename, opts, watch = false) {
+    try {
+        const code = fs.readFileSync(filename, 'utf8');
+        return transform(filename, code, opts);
+    } catch (err) {
+        if (watch) {
+            console.error(toErrorStack(err));
+            return { ignored: true };
+        }
+
+        throw err;
+    }
+}
+
+function toErrorStack(err) {
+    // eslint-disable-next-line
+    if (err._babel && err instanceof SyntaxError) {
+        return `${err.name}: ${err.message}\n${err.codeFrame}`;
+    }
+
+    return err.stack;
+}

--- a/extensions/roc-package-module-dev/src/actions/helpers/isSomeTargetValid.js
+++ b/extensions/roc-package-module-dev/src/actions/helpers/isSomeTargetValid.js
@@ -1,0 +1,3 @@
+export default function isSomeTargetValid(targets) {
+    return ['cjs', 'esm'].some((target) => targets.indexOf(target) > -1);
+}

--- a/extensions/roc-package-module-dev/src/actions/some-valid-target.js
+++ b/extensions/roc-package-module-dev/src/actions/some-valid-target.js
@@ -1,3 +1,0 @@
-export default function isSomeTargetValid(targets) {
-    return ['es5', 'es6'].some((target) => targets.indexOf(target) > -1);
-}

--- a/extensions/roc-package-module-dev/src/config/roc.config.js
+++ b/extensions/roc-package-module-dev/src/config/roc.config.js
@@ -1,12 +1,14 @@
 export default {
     settings: {
         build: {
-            targets: ['es5', 'es6'],
+            targets: ['cjs', 'esm'],
             input: 'src',
             output: {
-                es5: 'lib/es5',
-                es6: 'lib/es6',
+                cjs: 'lib/cjs',
+                esm: 'lib/esm',
             },
         },
     },
+
+    babel: undefined,
 };

--- a/extensions/roc-package-module-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-module-dev/src/config/roc.config.meta.js
@@ -12,7 +12,7 @@ export default {
                 override: 'roc-abstract-package-base-dev',
             },
             targets: {
-                validator: required(notEmpty(isArray(/^es5$|^es6$/i))),
+                validator: required(notEmpty(isArray(/^cjs$|^esm$/i))),
                 override: 'roc-abstract-package-base-dev',
             },
             input: {
@@ -24,15 +24,19 @@ export default {
                 __meta: {
                     override: 'roc-abstract-package-base-dev',
                 },
-                es5: {
-                    description: 'The output directory for the ES5 build.',
+                cjs: {
+                    description: 'The output directory for the CommonJS build.',
                     validator: required(notEmpty(isPath)),
                 },
-                es6: {
-                    description: 'The output directory for the ES6 build.',
+                esm: {
+                    description: 'The output directory for the ES Modules build.',
                     validator: required(notEmpty(isPath)),
                 },
             },
         },
+    },
+
+    babel: {
+        description: 'Babel configuration that can be either a plain object or a function that gets target as argument',
     },
 };


### PR DESCRIPTION
- Changed es5 and es6 builds to be called cjs and esm.
- Replaced old Babel hooks with a new one that is more generic.
- Updated to use babel-preset-latest over babel-preset-es2015
- Now uses babel-core directly instead of being a wrapper around babel-cli
- Uses the new roc-plugin-babel.
